### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository leverages [VSCode's devcontainer](https://code.visualstudio.com/
 To get started:
 
 ```bash
-npm init && npm start
+npm install && npm start
 ```
 
 This will start the application on your local machine, running on [http://localhost:3000/](http://localhost:3000).


### PR DESCRIPTION
It says that the command to run the project is `npm init`, it's probably a mistake because it's a command used to create a new project... probably a typo
This PR fixes that mistake