### PR TITLE
Show large single combo when clicking the item in bulk list

### DIFF
--- a/src/Components/kitchen.tsx
+++ b/src/Components/kitchen.tsx
@@ -255,7 +255,17 @@ export default function Kitchen() {
       })
       .map((combination) => {
         return (
-          <ImageListItem key={combination.alt}>
+          <ImageListItem
+            key={combination.alt}
+            onClick={() => {
+              handleRightEmojiClicked(
+                selectedLeftEmoji !== combination.rightEmojiCodepoint
+                  ? combination.rightEmojiCodepoint
+                  : combination.leftEmojiCodepoint
+              );
+              console.log("clicked");
+            }}
+          >
             <img
               loading="lazy"
               width="256px"

--- a/src/Components/kitchen.tsx
+++ b/src/Components/kitchen.tsx
@@ -263,7 +263,14 @@ export default function Kitchen() {
                   ? combination.rightEmojiCodepoint
                   : combination.leftEmojiCodepoint
               );
-              console.log("clicked");
+            }}
+            sx={{
+              p: 0.5,
+              borderRadius: 4,
+              backgroundColor: (theme) => theme.palette.background.default,
+              "&:hover": {
+                backgroundColor: (theme) => theme.palette.action.hover,
+              },
             }}
           >
             <img

--- a/src/Components/kitchen.tsx
+++ b/src/Components/kitchen.tsx
@@ -291,7 +291,11 @@ export default function Kitchen() {
 
     middleList = (
       <ImageListItem>
-        <img alt={combo.alt} src={combo.gStaticUrl} />
+        <img
+          alt={combo.alt}
+          src={combo.gStaticUrl}
+          onClick={() => setSelectedRightEmoji("")}
+        />
       </ImageListItem>
     );
   }


### PR DESCRIPTION
For #691 - when the single combo item in the bulk list is clicked, it opens the large single combo display (by setting the selected right list emoji); clicking the large single combo takes you back to the bulk list (by deselecting the right list emoji).